### PR TITLE
Add Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Convolutional autoencoder for genotype data, as described in [1]
 
 ## Installation
+
+### Manual Installation
 (examples for linux)
 
 #### Requirements:
@@ -19,6 +21,76 @@ pip3
     $ cd GenoCAE/
     $ pip3 install -r requirements.txt
 
+### Docker Installation
+
+#### Build Docker image
+
+``` Shell
+docker build -t gcae/genocae:build -f docker/build.dockerfile .
+```
+
+#### CLI
+
+``` Shell
+$ docker run -it --rm -v ${PWD}:/workspace gcae/genocae:build python3 run_gcae.py --help
+
+GenoCAE.
+
+Usage:
+  run_gcae.py train --datadir=<name> --data=<name> --model_id=<name> --train_opts_id=<name> --data_opts_id=<name> --save_interval=<num> --epochs=<num> [--resume_from=<num> --trainedmodeldir=<name> ]
+  run_gcae.py project --datadir=<name>   [ --data=<name> --model_id=<name>  --train_opts_id=<name> --data_opts_id=<name> --superpops=<name> --epoch=<num> --trainedmodeldir=<name>   --pdata=<name> --trainedmodelname=<name>]
+  run_gcae.py plot --datadir=<name> [  --data=<name>  --model_id=<name> --train_opts_id=<name> --data_opts_id=<name>  --superpops=<name> --epoch=<num> --trainedmodeldir=<name>  --pdata=<name> --trainedmodelname=<name>]
+  run_gcae.py animate --datadir=<name>   [ --data=<name>   --model_id=<name> --train_opts_id=<name> --data_opts_id=<name>  --superpops=<name> --epoch=<num> --trainedmodeldir=<name> --pdata=<name> --trainedmodelname=<name>]
+  run_gcae.py evaluate --datadir=<name> --metrics=<name>  [  --data=<name>  --model_id=<name> --train_opts_id=<name> --data_opts_id=<name>  --superpops=<name> --epoch=<num> --trainedmodeldir=<name>  --pdata=<name> --trainedmodelname=<name>]
+
+Options:
+  -h --help             show this screen
+  --datadir=<name>       directory where sample data is stored
+  --data=<name>         file prefix, not including path, of the data files (EIGENSTRAT of PLINK format)
+  --trainedmodeldir=<name>     base path where to save model training directories. default: ae_out/
+  --model_id=<name>     model id, corresponding to a file models/model_id.json
+  --train_opts_id=<name>train options id, corresponding to a file train_opts/train_opts_id.json
+  --data_opts_id=<name> data options id, corresponding to a file data_opts/data_opts_id.json
+  --epochs<num>         number of epochs to train
+  --resume_from<num>    saved epoch to resume training from. set to -1 for latest saved epoch.
+  --save_interval<num>  epoch intervals at which to save state of model, and at which to calculate the valid loss
+  --trainedmodelname=<name> name of the model training directory to fetch saved model state from when project/plot/evaluating
+  --pdata=<name>        file prefix, not including path, of data to project/plot/evaluate. if not specified, assumed to be the same the model was trained on.
+  --epoch<num>          epoch at which to project/plot/evaluate data. if not specified, all saved epochs will be used
+  --superpops<name>     path+filename of file mapping populations to superpopulations. used to color populations of the same superpopulation in similar colors in plotting.
+  --metrics=<name>      the metric(s) to evaluate, e.g. hull_error of f1 score. can pass a list with multiple metrics, e.g. "hull_error,f1_score"
+```
+
+If you have a Docker with GPU support.
+``` Shell
+$ docker run -it  --gpus=all --rm -v ${PWD}:/workspace gcae/genocae:build python3 run_gcae.py --help
+
+GenoCAE.
+
+Usage:
+  run_gcae.py train --datadir=<name> --data=<name> --model_id=<name> --train_opts_id=<name> --data_opts_id=<name> --save_interval=<num> --epochs=<num> [--resume_from=<num> --trainedmodeldir=<name> ]
+  run_gcae.py project --datadir=<name>   [ --data=<name> --model_id=<name>  --train_opts_id=<name> --data_opts_id=<name> --superpops=<name> --epoch=<num> --trainedmodeldir=<name>   --pdata=<name> --trainedmodelname=<name>]
+  run_gcae.py plot --datadir=<name> [  --data=<name>  --model_id=<name> --train_opts_id=<name> --data_opts_id=<name>  --superpops=<name> --epoch=<num> --trainedmodeldir=<name>  --pdata=<name> --trainedmodelname=<name>]
+  run_gcae.py animate --datadir=<name>   [ --data=<name>   --model_id=<name> --train_opts_id=<name> --data_opts_id=<name>  --superpops=<name> --epoch=<num> --trainedmodeldir=<name> --pdata=<name> --trainedmodelname=<name>]
+  run_gcae.py evaluate --datadir=<name> --metrics=<name>  [  --data=<name>  --model_id=<name> --train_opts_id=<name> --data_opts_id=<name>  --superpops=<name> --epoch=<num> --trainedmodeldir=<name>  --pdata=<name> --trainedmodelname=<name>]
+
+Options:
+  -h --help             show this screen
+  --datadir=<name>       directory where sample data is stored
+  --data=<name>         file prefix, not including path, of the data files (EIGENSTRAT of PLINK format)
+  --trainedmodeldir=<name>     base path where to save model training directories. default: ae_out/
+  --model_id=<name>     model id, corresponding to a file models/model_id.json
+  --train_opts_id=<name>train options id, corresponding to a file train_opts/train_opts_id.json
+  --data_opts_id=<name> data options id, corresponding to a file data_opts/data_opts_id.json
+  --epochs<num>         number of epochs to train
+  --resume_from<num>    saved epoch to resume training from. set to -1 for latest saved epoch.
+  --save_interval<num>  epoch intervals at which to save state of model, and at which to calculate the valid loss
+  --trainedmodelname=<name> name of the model training directory to fetch saved model state from when project/plot/evaluating
+  --pdata=<name>        file prefix, not including path, of data to project/plot/evaluate. if not specified, assumed to be the same the model was trained on.
+  --epoch<num>          epoch at which to project/plot/evaluate data. if not specified, all saved epochs will be used
+  --superpops<name>     path+filename of file mapping populations to superpopulations. used to color populations of the same superpopulation in similar colors in plotting.
+  --metrics=<name>      the metric(s) to evaluate, e.g. hull_error of f1 score. can pass a list with multiple metrics, e.g. "hull_error,f1_score"
+```
 
 ## CLI
 

--- a/docker/build.dockerfile
+++ b/docker/build.dockerfile
@@ -26,7 +26,6 @@ RUN pip3 install --upgrade pip
 WORKDIR /workspace
 ADD ./requirements.txt /workspace
 RUN pip3 install -r /workspace/requirements.txt and &&\
-	rm /workspace/requirements.txt &&\
-    pip3 install tensorflow-gpu==2.2.0
+	rm /workspace/requirements.txt
 
 CMD ["/bin/bash"]

--- a/docker/build.dockerfile
+++ b/docker/build.dockerfile
@@ -1,0 +1,32 @@
+ARG CUDA_VERSION=11.1.1
+ARG OS_VERSION=20.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu${OS_VERSION}
+
+LABEL maintainer="Dong Wang"
+
+
+ENV PATH="/root/miniconda3/bin:${PATH}"
+ARG PATH="/root/miniconda3/bin:${PATH}"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get upgrade -y &&\
+    apt-get install -y wget
+
+# Python
+RUN wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
+
+RUN pip3 install --upgrade pip
+
+WORKDIR /workspace
+ADD ./requirements.txt /workspace
+RUN pip3 install -r /workspace/requirements.txt and &&\
+	rm /workspace/requirements.txt &&\
+    pip3 install tensorflow-gpu==2.2.0
+
+CMD ["/bin/bash"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docopt
 grpcio
 setuptools==47.1.1
-tensorflow==2.1.0
+tensorflow>=2.2.0
 numpy==1.18.4
 scikit-learn
 matplotlib==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docopt
 grpcio
 setuptools==47.1.1
-tensorflow>=2.2.0
+tensorflow==2.2.0
 numpy==1.18.4
 scikit-learn
 matplotlib==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docopt
 grpcio
 setuptools==47.1.1
-tensorflow==2.2.0
+tensorflow>=2.2.0
 numpy==1.18.4
 scikit-learn
 matplotlib==3.2.1


### PR DESCRIPTION
Hi,

It is an interesting project, using convlutional autoencoder for genotype data.

I find the current dependencies in requirements.txt are outdated. For example, there is no TensorFlow=2.2.1 via 'pip install'.  For the repeatability of the experiments, I provide a Dockerfile based on 'nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04'. You can deploy an environment on any Docker-supported platform such as Windows, macOS, and Linux.

After building a Docker image by

```
docker build -t gcae/genocae:build -f docker/build.dockerfile .
```

You can train models via 

```
docker run -it --rm -v ${PWD}:/workspace gcae/genocae:build  python3 run_gcae.py train --datadir example_tiny/ --data HumanOrigins249_tiny --model_id M1  --epochs 20 --save_interval 2  --train_opts_id ex3  --data_opts_id b_0_4
```
