### PR TITLE
Fix reference to article

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,5 +454,5 @@ See [tips](tips.md) for some rules of thumb for model architecture settings and 
 
 ## References
 
- * [1] Ausmees, Kristiina and Nettelblad, Carl. "A deep learning framework for characterization of genotype data." bioRxiv (2020). [here](https://www.biorxiv.org/content/10.1101/2020.09.30.320994v1.abstract)
+ * [1] Kristiina Ausmees, Carl Nettelblad, A deep learning framework for characterization of genotype data, G3 Genes|Genomes|Genetics, 2022;, jkac020, [https://doi.org/10.1093/g3journal/jkac020](https://doi.org/10.1093/g3journal/jkac020)
 


### PR DESCRIPTION
Dear GenoCAE maintainers, hi @kausmees,

Congrats with the publication of the article on GenoCAE! Here I update the link to that article. Note that I used the citation format as suggested by that journal (or: the `;,`) is not my idea.

Hope you enjoy keeping this updated!

Note that `check.yaml` fails, which I reported at #26, the fix will be part of another Pull Request.

Cheers, Richel