### PR TITLE
Fix 'check.yaml', fix #26

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,5 +1,4 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Determine if GCAE can do a minimal run
 on:
   push:
   pull_request:
@@ -17,15 +16,17 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v1
 
-      - name: Install libgit2-dev
-        run: sudo apt install -qq libgit2-dev
-
       - name: Install libcurl4-openssl-dev
         run: sudo apt install -qq libcurl4-openssl-dev
 
-      - name: Install dependencies
-        run: pip3 install -r requirements.txt
+      - name: Install python3-pip, thanks Pavlin Mitev
+        run: |
+          sudo apt install -qq python3-pip
+          python3 -m pip install --upgrade pip
 
-      - name: Training and evaluation of models help
+      - name: Install dependencies using python3, thanks Pavlin Mitev
+        run: python3 -m pip install -r requirements.txt
+
+      - name: Show help
         run: python3 run_gcae.py --help
 


### PR DESCRIPTION
Dear GenoCAE maintainer, hi @kausmees,

Thanks for GenoCAE and I am happy that continuous integration is enabled to show off its quality!

Currently, however, the build fails, which I reported at #26, due to changes upstream. Here is the fix for that! I did not add anything new to the `check.yaml` script, just made it to work with a minimal amount of changes.

Cheers, Richek